### PR TITLE
WIP: Re-render with a development build of `conda-smithy` after 0.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -27,10 +30,11 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda config --add channels conda-team
+      conda config --add channels conda-team/label/dev
       conda config --add channels conda-forge
-      
+      conda update --yes conda
+      conda install --yes conda-build jinja2 anaconda-client
 
 script:
   - conda build ./recipe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,14 +60,13 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-team
+    - cmd: conda config --add channels conda-team/label/dev
+    - cmd: conda config --add channels conda-forge
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
+    - cmd: conda update --yes --quiet --all
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,8 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
+ - conda-team
+ - conda-team/label/dev
  - defaults # As we need conda-build
 
 conda-build:
@@ -40,7 +41,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 3 case(s).


### PR DESCRIPTION
Re-renders apptools with this PR ( https://github.com/conda-forge/conda-smithy/pull/156 ).

As apptools was one of the canonical failures for Windows Python 3.4 64-bit ( https://github.com/conda-forge/staged-recipes/issues/448 ). Also, as it is Python, it would suffer from the shebang bug on Mac as explained in this `conda-build` issue ( https://github.com/conda/conda-build/issues/889 ). As both of these should be fixed in the development release of `conda-build`, this is not only good for testing that the re-rendering generated functioning CI config files, but it should demonstrate whether both of those issues are indeed fixed.
